### PR TITLE
Parse HTTP proxy credentials from URL and populate settings

### DIFF
--- a/src/common/settings.json
+++ b/src/common/settings.json
@@ -850,7 +850,7 @@
     },
     {
         "name": "http_proxy",
-        "description": "HTTP proxy host (defaults to the HTTP_PROXY environment variable when unset)",
+        "description": "HTTP proxy host (defaults to the HTTPS_PROXY / HTTP_PROXY environment variable when unset; the URL may embed `user[:password]@`, which then populates http_proxy_username / http_proxy_password)",
         "type": "VARCHAR",
         "scope": "global",
         "struct": "HTTPProxySetting",

--- a/src/common/settings.json
+++ b/src/common/settings.json
@@ -850,7 +850,7 @@
     },
     {
         "name": "http_proxy",
-        "description": "HTTP proxy host (defaults to the HTTPS_PROXY / HTTP_PROXY environment variable when unset; the URL may embed `user[:password]@`, which then populates http_proxy_username / http_proxy_password)",
+        "description": "HTTP proxy host (defaults to the https_proxy / http_proxy environment variable when unset, falling back to the uppercase forms; the URL may embed `user[:password]@`, which then populates http_proxy_username / http_proxy_password)",
         "type": "VARCHAR",
         "scope": "global",
         "struct": "HTTPProxySetting",

--- a/src/include/duckdb/main/settings.hpp
+++ b/src/include/duckdb/main/settings.hpp
@@ -1273,7 +1273,8 @@ struct HTTPProxySetting {
 	using RETURN_TYPE = string;
 	static constexpr const char *Name = "http_proxy";
 	static constexpr const char *Description =
-	    "HTTP proxy host (defaults to the HTTP_PROXY environment variable when unset)";
+	    "HTTP proxy host (defaults to the HTTPS_PROXY / HTTP_PROXY environment variable when unset; the URL may embed "
+	    "`user[:password]@`, which then populates http_proxy_username / http_proxy_password)";
 	static constexpr const char *InputType = "VARCHAR";
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);

--- a/src/include/duckdb/main/settings.hpp
+++ b/src/include/duckdb/main/settings.hpp
@@ -1273,8 +1273,9 @@ struct HTTPProxySetting {
 	using RETURN_TYPE = string;
 	static constexpr const char *Name = "http_proxy";
 	static constexpr const char *Description =
-	    "HTTP proxy host (defaults to the HTTPS_PROXY / HTTP_PROXY environment variable when unset; the URL may embed "
-	    "`user[:password]@`, which then populates http_proxy_username / http_proxy_password)";
+	    "HTTP proxy host (defaults to the https_proxy / http_proxy environment variable when unset, falling back to "
+	    "the uppercase forms; the URL may embed `user[:password]@`, which then populates http_proxy_username / "
+	    "http_proxy_password)";
 	static constexpr const char *InputType = "VARCHAR";
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);

--- a/src/main/http/http_util.cpp
+++ b/src/main/http/http_util.cpp
@@ -296,6 +296,8 @@ void HTTPUtil::ParseHTTPProxyHost(string &proxy_value, string &hostname_out, idx
 	auto sanitized_proxy_value = proxy_value;
 	if (StringUtil::StartsWith(proxy_value, "http://")) {
 		sanitized_proxy_value = proxy_value.substr(7);
+	} else if (StringUtil::StartsWith(proxy_value, "https://")) {
+		sanitized_proxy_value = proxy_value.substr(8);
 	}
 	auto proxy_split = StringUtil::Split(sanitized_proxy_value, ":");
 	if (proxy_split.size() == 1) {

--- a/src/main/settings/custom_settings.cpp
+++ b/src/main/settings/custom_settings.cpp
@@ -1054,8 +1054,7 @@ void ApplyHTTPProxyURL(DBConfig &config, string proxy) {
 		if (!userinfo.empty()) {
 			auto colon_pos = userinfo.find(':');
 			string username = colon_pos == string::npos ? std::move(userinfo) : userinfo.substr(0, colon_pos);
-			config.user_settings.SetUserSetting(HTTPProxyUsernameSetting::SettingIndex,
-			                                    Value(std::move(username)));
+			config.user_settings.SetUserSetting(HTTPProxyUsernameSetting::SettingIndex, Value(std::move(username)));
 			if (colon_pos != string::npos) {
 				config.user_settings.SetUserSetting(HTTPProxyPasswordSetting::SettingIndex,
 				                                    Value(userinfo.substr(colon_pos + 1)));

--- a/src/main/settings/custom_settings.cpp
+++ b/src/main/settings/custom_settings.cpp
@@ -1043,12 +1043,16 @@ void ApplyHTTPProxyURL(DBConfig &config, string proxy) {
 		return;
 	}
 	idx_t userinfo_start = scheme_end + 3;
-	// Userinfo (if any) lives in the authority component, which ends at the
-	// first '/', '?' or '#' character (RFC 3986 §3.2); a later '@' belongs to
-	// the path / query / fragment and must not be treated as a credential.
-	auto authority_end = proxy.find_first_of("/?#", userinfo_start);
 	auto at_pos = proxy.find('@', userinfo_start);
-	if (at_pos == string::npos || (authority_end != string::npos && at_pos > authority_end)) {
+	if (at_pos == string::npos) {
+		config.options.http_proxy = std::move(proxy);
+		return;
+	}
+	// RFC 3986 §3.2: the authority component ends at the first '/', '?' or
+	// '#'. A later '@' belongs to the path / query / fragment and is not
+	// userinfo, so don't treat it as a credential.
+	auto authority_end = proxy.find_first_of("/?#", userinfo_start);
+	if (authority_end != string::npos && at_pos > authority_end) {
 		config.options.http_proxy = std::move(proxy);
 		return;
 	}
@@ -1056,6 +1060,8 @@ void ApplyHTTPProxyURL(DBConfig &config, string proxy) {
 	// Drop `userinfo@` from the URL whether or not credentials were extracted,
 	// so the remainder is the bare proxy authority.
 	proxy.erase(userinfo_start, at_pos - userinfo_start + 1);
+	// An empty `@` block (e.g. `http://@host`) is malformed userinfo; leave
+	// the existing credential settings alone instead of clobbering them.
 	if (!userinfo.empty()) {
 		auto colon_pos = userinfo.find(':');
 		string username = colon_pos == string::npos ? std::move(userinfo) : userinfo.substr(0, colon_pos);

--- a/src/main/settings/custom_settings.cpp
+++ b/src/main/settings/custom_settings.cpp
@@ -1062,14 +1062,16 @@ void ApplyHTTPProxyURL(DBConfig &config, string proxy) {
 	proxy.erase(userinfo_start, at_pos - userinfo_start + 1);
 	// An empty `@` block (e.g. `http://@host`) is malformed userinfo; leave
 	// the existing credential settings alone instead of clobbering them.
-	if (!userinfo.empty()) {
-		auto colon_pos = userinfo.find(':');
-		string username = colon_pos == string::npos ? std::move(userinfo) : userinfo.substr(0, colon_pos);
-		config.user_settings.SetUserSetting(HTTPProxyUsernameSetting::SettingIndex, Value(std::move(username)));
-		if (colon_pos != string::npos) {
-			config.user_settings.SetUserSetting(HTTPProxyPasswordSetting::SettingIndex,
-			                                    Value(userinfo.substr(colon_pos + 1)));
-		}
+	if (userinfo.empty()) {
+		config.options.http_proxy = std::move(proxy);
+		return;
+	}
+	auto colon_pos = userinfo.find(':');
+	string username = colon_pos == string::npos ? std::move(userinfo) : userinfo.substr(0, colon_pos);
+	config.user_settings.SetUserSetting(HTTPProxyUsernameSetting::SettingIndex, Value(std::move(username)));
+	if (colon_pos != string::npos) {
+		config.user_settings.SetUserSetting(HTTPProxyPasswordSetting::SettingIndex,
+		                                    Value(userinfo.substr(colon_pos + 1)));
 	}
 	config.options.http_proxy = std::move(proxy);
 }

--- a/src/main/settings/custom_settings.cpp
+++ b/src/main/settings/custom_settings.cpp
@@ -1041,12 +1041,21 @@ void ExtractHTTPProxyCredentials(DBConfig &config, string &proxy) {
 	if (scheme_end != string::npos) {
 		userinfo_start = scheme_end + 3;
 	}
-	auto path_start = proxy.find('/', userinfo_start);
+	// Userinfo (if any) lives in the authority component, which ends at the
+	// first '/', '?' or '#' character (RFC 3986 §3.2); a later '@' belongs to
+	// the path / query / fragment and must not be treated as a credential.
+	auto authority_end = proxy.find_first_of("/?#", userinfo_start);
 	auto at_pos = proxy.find('@', userinfo_start);
-	if (at_pos == string::npos || (path_start != string::npos && at_pos > path_start)) {
+	if (at_pos == string::npos || (authority_end != string::npos && at_pos > authority_end)) {
 		return;
 	}
 	auto userinfo = proxy.substr(userinfo_start, at_pos - userinfo_start);
+	// Drop `userinfo@` from the URL whether or not credentials were extracted,
+	// so the remainder is the bare proxy authority.
+	proxy.erase(userinfo_start, at_pos - userinfo_start + 1);
+	if (userinfo.empty()) {
+		return;
+	}
 	auto colon_pos = userinfo.find(':');
 	string username = colon_pos == string::npos ? std::move(userinfo) : userinfo.substr(0, colon_pos);
 	config.user_settings.SetUserSetting(HTTPProxyUsernameSetting::SettingIndex, Value(std::move(username)));
@@ -1054,7 +1063,6 @@ void ExtractHTTPProxyCredentials(DBConfig &config, string &proxy) {
 		config.user_settings.SetUserSetting(HTTPProxyPasswordSetting::SettingIndex,
 		                                    Value(userinfo.substr(colon_pos + 1)));
 	}
-	proxy.erase(userinfo_start, at_pos - userinfo_start + 1);
 }
 
 } // namespace

--- a/src/main/settings/custom_settings.cpp
+++ b/src/main/settings/custom_settings.cpp
@@ -1031,47 +1031,63 @@ Value ForceMbedtlsUnsafeSetting::GetSetting(const ClientContext &context) {
 //===----------------------------------------------------------------------===//
 namespace {
 
-// Assign a proxy URL to the `http_proxy` option, splitting any embedded
-// `user[:password]@` userinfo into the matching `http_proxy_username` /
-// `http_proxy_password` settings. The credential settings are only touched
-// when an explicit scheme is present and a non-empty userinfo is found —
-// a bare `host:port` (no scheme) is too ambiguous to parse safely.
-void ApplyHTTPProxyURL(DBConfig &config, string proxy) {
+enum class ProxyCredentials { NONE, USERNAME_ONLY, USERNAME_AND_PASSWORD };
+
+// Strip a `user[:password]@` userinfo component from the authority part of
+// `proxy` in place. The return value tells the caller which of `username` /
+// `password` were populated:
+//
+//   NONE                   - neither output was touched
+//   USERNAME_ONLY          - only `username` is valid (no `:` in userinfo)
+//   USERNAME_AND_PASSWORD  - both outputs are valid
+//
+// Returns NONE without parsing when the URL has no `://` scheme (a bare
+// `host:port` is too ambiguous), when no `@` is present in the authority,
+// or when the userinfo block is empty (e.g. `http://@host` — leave existing
+// credential settings alone instead of clobbering them).
+ProxyCredentials ExtractProxyCredentials(string &proxy, string &username, string &password) {
 	auto scheme_end = proxy.find("://");
 	if (scheme_end == string::npos) {
-		config.options.http_proxy = std::move(proxy);
-		return;
+		return ProxyCredentials::NONE;
 	}
 	idx_t userinfo_start = scheme_end + 3;
 	auto at_pos = proxy.find('@', userinfo_start);
 	if (at_pos == string::npos) {
-		config.options.http_proxy = std::move(proxy);
-		return;
+		return ProxyCredentials::NONE;
 	}
 	// RFC 3986 §3.2: the authority component ends at the first '/', '?' or
 	// '#'. A later '@' belongs to the path / query / fragment and is not
 	// userinfo, so don't treat it as a credential.
 	auto authority_end = proxy.find_first_of("/?#", userinfo_start);
 	if (authority_end != string::npos && at_pos > authority_end) {
-		config.options.http_proxy = std::move(proxy);
-		return;
+		return ProxyCredentials::NONE;
 	}
 	auto userinfo = proxy.substr(userinfo_start, at_pos - userinfo_start);
-	// Drop `userinfo@` from the URL whether or not credentials were extracted,
-	// so the remainder is the bare proxy authority.
+	// Drop `userinfo@` from the URL whether or not we end up extracting
+	// credentials, so the remainder is the bare proxy authority.
 	proxy.erase(userinfo_start, at_pos - userinfo_start + 1);
-	// An empty `@` block (e.g. `http://@host`) is malformed userinfo; leave
-	// the existing credential settings alone instead of clobbering them.
 	if (userinfo.empty()) {
-		config.options.http_proxy = std::move(proxy);
-		return;
+		return ProxyCredentials::NONE;
 	}
 	auto colon_pos = userinfo.find(':');
-	string username = colon_pos == string::npos ? std::move(userinfo) : userinfo.substr(0, colon_pos);
-	config.user_settings.SetUserSetting(HTTPProxyUsernameSetting::SettingIndex, Value(std::move(username)));
-	if (colon_pos != string::npos) {
-		config.user_settings.SetUserSetting(HTTPProxyPasswordSetting::SettingIndex,
-		                                    Value(userinfo.substr(colon_pos + 1)));
+	if (colon_pos == string::npos) {
+		username = std::move(userinfo);
+		return ProxyCredentials::USERNAME_ONLY;
+	}
+	username = userinfo.substr(0, colon_pos);
+	password = userinfo.substr(colon_pos + 1);
+	return ProxyCredentials::USERNAME_AND_PASSWORD;
+}
+
+void ApplyHTTPProxyURL(DBConfig &config, string proxy) {
+	string username;
+	string password;
+	auto extracted = ExtractProxyCredentials(proxy, username, password);
+	if (extracted != ProxyCredentials::NONE) {
+		config.user_settings.SetUserSetting(HTTPProxyUsernameSetting::SettingIndex, Value(std::move(username)));
+	}
+	if (extracted == ProxyCredentials::USERNAME_AND_PASSWORD) {
+		config.user_settings.SetUserSetting(HTTPProxyPasswordSetting::SettingIndex, Value(std::move(password)));
 	}
 	config.options.http_proxy = std::move(proxy);
 }

--- a/src/main/settings/custom_settings.cpp
+++ b/src/main/settings/custom_settings.cpp
@@ -1029,12 +1029,49 @@ Value ForceMbedtlsUnsafeSetting::GetSetting(const ClientContext &context) {
 //===----------------------------------------------------------------------===//
 // HTTP Proxy
 //===----------------------------------------------------------------------===//
+namespace {
+
+// Extract a `user[:password]@` userinfo component from a proxy URL, store the
+// parts in the `http_proxy_username` / `http_proxy_password` settings, and
+// strip it from `proxy` in place. Leaves `proxy` and the credential settings
+// untouched when no userinfo is present.
+void ExtractHTTPProxyCredentials(DBConfig &config, string &proxy) {
+	idx_t userinfo_start = 0;
+	auto scheme_end = proxy.find("://");
+	if (scheme_end != string::npos) {
+		userinfo_start = scheme_end + 3;
+	}
+	auto path_start = proxy.find('/', userinfo_start);
+	auto at_pos = proxy.find('@', userinfo_start);
+	if (at_pos == string::npos || (path_start != string::npos && at_pos > path_start)) {
+		return;
+	}
+	auto userinfo = proxy.substr(userinfo_start, at_pos - userinfo_start);
+	auto colon_pos = userinfo.find(':');
+	string username = colon_pos == string::npos ? std::move(userinfo) : userinfo.substr(0, colon_pos);
+	config.user_settings.SetUserSetting(HTTPProxyUsernameSetting::SettingIndex, Value(std::move(username)));
+	if (colon_pos != string::npos) {
+		config.user_settings.SetUserSetting(HTTPProxyPasswordSetting::SettingIndex,
+		                                    Value(userinfo.substr(colon_pos + 1)));
+	}
+	proxy.erase(userinfo_start, at_pos - userinfo_start + 1);
+}
+
+} // namespace
+
 void HTTPProxySetting::SetGlobal(DatabaseInstance *, DBConfig &config, const Value &input) {
-	config.options.http_proxy = input.GetValue<string>();
+	auto proxy = input.GetValue<string>();
+	ExtractHTTPProxyCredentials(config, proxy);
+	config.options.http_proxy = std::move(proxy);
 }
 
 void HTTPProxySetting::ResetGlobal(DatabaseInstance *, DBConfig &config) {
-	config.options.http_proxy = FileSystem::GetEnvVariable("HTTP_PROXY");
+	auto proxy = FileSystem::GetEnvVariable("HTTPS_PROXY");
+	if (proxy.empty()) {
+		proxy = FileSystem::GetEnvVariable("HTTP_PROXY");
+	}
+	ExtractHTTPProxyCredentials(config, proxy);
+	config.options.http_proxy = std::move(proxy);
 }
 
 //===----------------------------------------------------------------------===//

--- a/src/main/settings/custom_settings.cpp
+++ b/src/main/settings/custom_settings.cpp
@@ -1031,11 +1031,11 @@ Value ForceMbedtlsUnsafeSetting::GetSetting(const ClientContext &context) {
 //===----------------------------------------------------------------------===//
 namespace {
 
-// Extract a `user[:password]@` userinfo component from a proxy URL, store the
-// parts in the `http_proxy_username` / `http_proxy_password` settings, and
-// strip it from `proxy` in place. Leaves `proxy` and the credential settings
-// untouched when no userinfo is present.
-void ExtractHTTPProxyCredentials(DBConfig &config, string &proxy) {
+// Assign a proxy URL to the `http_proxy` option, splitting any embedded
+// `user[:password]@` userinfo into the matching `http_proxy_username` /
+// `http_proxy_password` settings. The credential settings are only touched
+// when a non-empty userinfo is found.
+void ApplyHTTPProxyURL(DBConfig &config, string proxy) {
 	idx_t userinfo_start = 0;
 	auto scheme_end = proxy.find("://");
 	if (scheme_end != string::npos) {
@@ -1046,31 +1046,29 @@ void ExtractHTTPProxyCredentials(DBConfig &config, string &proxy) {
 	// the path / query / fragment and must not be treated as a credential.
 	auto authority_end = proxy.find_first_of("/?#", userinfo_start);
 	auto at_pos = proxy.find('@', userinfo_start);
-	if (at_pos == string::npos || (authority_end != string::npos && at_pos > authority_end)) {
-		return;
+	if (at_pos != string::npos && (authority_end == string::npos || at_pos < authority_end)) {
+		auto userinfo = proxy.substr(userinfo_start, at_pos - userinfo_start);
+		// Drop `userinfo@` from the URL whether or not credentials were extracted,
+		// so the remainder is the bare proxy authority.
+		proxy.erase(userinfo_start, at_pos - userinfo_start + 1);
+		if (!userinfo.empty()) {
+			auto colon_pos = userinfo.find(':');
+			string username = colon_pos == string::npos ? std::move(userinfo) : userinfo.substr(0, colon_pos);
+			config.user_settings.SetUserSetting(HTTPProxyUsernameSetting::SettingIndex,
+			                                    Value(std::move(username)));
+			if (colon_pos != string::npos) {
+				config.user_settings.SetUserSetting(HTTPProxyPasswordSetting::SettingIndex,
+				                                    Value(userinfo.substr(colon_pos + 1)));
+			}
+		}
 	}
-	auto userinfo = proxy.substr(userinfo_start, at_pos - userinfo_start);
-	// Drop `userinfo@` from the URL whether or not credentials were extracted,
-	// so the remainder is the bare proxy authority.
-	proxy.erase(userinfo_start, at_pos - userinfo_start + 1);
-	if (userinfo.empty()) {
-		return;
-	}
-	auto colon_pos = userinfo.find(':');
-	string username = colon_pos == string::npos ? std::move(userinfo) : userinfo.substr(0, colon_pos);
-	config.user_settings.SetUserSetting(HTTPProxyUsernameSetting::SettingIndex, Value(std::move(username)));
-	if (colon_pos != string::npos) {
-		config.user_settings.SetUserSetting(HTTPProxyPasswordSetting::SettingIndex,
-		                                    Value(userinfo.substr(colon_pos + 1)));
-	}
+	config.options.http_proxy = std::move(proxy);
 }
 
 } // namespace
 
 void HTTPProxySetting::SetGlobal(DatabaseInstance *, DBConfig &config, const Value &input) {
-	auto proxy = input.GetValue<string>();
-	ExtractHTTPProxyCredentials(config, proxy);
-	config.options.http_proxy = std::move(proxy);
+	ApplyHTTPProxyURL(config, input.GetValue<string>());
 }
 
 void HTTPProxySetting::ResetGlobal(DatabaseInstance *, DBConfig &config) {
@@ -1085,8 +1083,7 @@ void HTTPProxySetting::ResetGlobal(DatabaseInstance *, DBConfig &config) {
 			break;
 		}
 	}
-	ExtractHTTPProxyCredentials(config, proxy);
-	config.options.http_proxy = std::move(proxy);
+	ApplyHTTPProxyURL(config, std::move(proxy));
 }
 
 //===----------------------------------------------------------------------===//

--- a/src/main/settings/custom_settings.cpp
+++ b/src/main/settings/custom_settings.cpp
@@ -1066,9 +1066,16 @@ void HTTPProxySetting::SetGlobal(DatabaseInstance *, DBConfig &config, const Val
 }
 
 void HTTPProxySetting::ResetGlobal(DatabaseInstance *, DBConfig &config) {
-	auto proxy = FileSystem::GetEnvVariable("HTTPS_PROXY");
-	if (proxy.empty()) {
-		proxy = FileSystem::GetEnvVariable("HTTP_PROXY");
+	// Prefer lowercase, which is the de-facto standard followed by curl/wget and
+	// avoids the `HTTP_PROXY` (uppercase) CGI httpoxy ambiguity; fall back to
+	// uppercase for compatibility. HTTPS takes precedence over HTTP.
+	static const char *kEnvVars[] = {"https_proxy", "HTTPS_PROXY", "http_proxy", "HTTP_PROXY"};
+	string proxy;
+	for (auto *name : kEnvVars) {
+		proxy = FileSystem::GetEnvVariable(name);
+		if (!proxy.empty()) {
+			break;
+		}
 	}
 	ExtractHTTPProxyCredentials(config, proxy);
 	config.options.http_proxy = std::move(proxy);

--- a/src/main/settings/custom_settings.cpp
+++ b/src/main/settings/custom_settings.cpp
@@ -1034,31 +1034,35 @@ namespace {
 // Assign a proxy URL to the `http_proxy` option, splitting any embedded
 // `user[:password]@` userinfo into the matching `http_proxy_username` /
 // `http_proxy_password` settings. The credential settings are only touched
-// when a non-empty userinfo is found.
+// when an explicit scheme is present and a non-empty userinfo is found —
+// a bare `host:port` (no scheme) is too ambiguous to parse safely.
 void ApplyHTTPProxyURL(DBConfig &config, string proxy) {
-	idx_t userinfo_start = 0;
 	auto scheme_end = proxy.find("://");
-	if (scheme_end != string::npos) {
-		userinfo_start = scheme_end + 3;
+	if (scheme_end == string::npos) {
+		config.options.http_proxy = std::move(proxy);
+		return;
 	}
+	idx_t userinfo_start = scheme_end + 3;
 	// Userinfo (if any) lives in the authority component, which ends at the
 	// first '/', '?' or '#' character (RFC 3986 §3.2); a later '@' belongs to
 	// the path / query / fragment and must not be treated as a credential.
 	auto authority_end = proxy.find_first_of("/?#", userinfo_start);
 	auto at_pos = proxy.find('@', userinfo_start);
-	if (at_pos != string::npos && (authority_end == string::npos || at_pos < authority_end)) {
-		auto userinfo = proxy.substr(userinfo_start, at_pos - userinfo_start);
-		// Drop `userinfo@` from the URL whether or not credentials were extracted,
-		// so the remainder is the bare proxy authority.
-		proxy.erase(userinfo_start, at_pos - userinfo_start + 1);
-		if (!userinfo.empty()) {
-			auto colon_pos = userinfo.find(':');
-			string username = colon_pos == string::npos ? std::move(userinfo) : userinfo.substr(0, colon_pos);
-			config.user_settings.SetUserSetting(HTTPProxyUsernameSetting::SettingIndex, Value(std::move(username)));
-			if (colon_pos != string::npos) {
-				config.user_settings.SetUserSetting(HTTPProxyPasswordSetting::SettingIndex,
-				                                    Value(userinfo.substr(colon_pos + 1)));
-			}
+	if (at_pos == string::npos || (authority_end != string::npos && at_pos > authority_end)) {
+		config.options.http_proxy = std::move(proxy);
+		return;
+	}
+	auto userinfo = proxy.substr(userinfo_start, at_pos - userinfo_start);
+	// Drop `userinfo@` from the URL whether or not credentials were extracted,
+	// so the remainder is the bare proxy authority.
+	proxy.erase(userinfo_start, at_pos - userinfo_start + 1);
+	if (!userinfo.empty()) {
+		auto colon_pos = userinfo.find(':');
+		string username = colon_pos == string::npos ? std::move(userinfo) : userinfo.substr(0, colon_pos);
+		config.user_settings.SetUserSetting(HTTPProxyUsernameSetting::SettingIndex, Value(std::move(username)));
+		if (colon_pos != string::npos) {
+			config.user_settings.SetUserSetting(HTTPProxyPasswordSetting::SettingIndex,
+			                                    Value(userinfo.substr(colon_pos + 1)));
 		}
 	}
 	config.options.http_proxy = std::move(proxy);

--- a/test/sql/settings/http_proxy.test
+++ b/test/sql/settings/http_proxy.test
@@ -6,39 +6,19 @@
 statement ok
 SET http_proxy = 'proxy.example.com:8080'
 
-query I
-SELECT current_setting('http_proxy')
+query III
+SELECT current_setting('http_proxy'), current_setting('http_proxy_username'), current_setting('http_proxy_password')
 ----
-proxy.example.com:8080
-
-query I
-SELECT current_setting('http_proxy_username')
-----
-(empty)
-
-query I
-SELECT current_setting('http_proxy_password')
-----
-(empty)
+proxy.example.com:8080	(empty)	(empty)
 
 # A scheme is preserved and `user:pass@` populates the credential settings
 statement ok
 SET http_proxy = 'https://alice:s3cr3t@proxy.example.com:8443'
 
-query I
-SELECT current_setting('http_proxy')
+query III
+SELECT current_setting('http_proxy'), current_setting('http_proxy_username'), current_setting('http_proxy_password')
 ----
-https://proxy.example.com:8443
-
-query I
-SELECT current_setting('http_proxy_username')
-----
-alice
-
-query I
-SELECT current_setting('http_proxy_password')
-----
-s3cr3t
+https://proxy.example.com:8443	alice	s3cr3t
 
 # Username only (no password) is supported
 statement ok
@@ -47,20 +27,10 @@ SET http_proxy_password = ''
 statement ok
 SET http_proxy = 'http://bob@proxy.example.com:3128'
 
-query I
-SELECT current_setting('http_proxy')
+query III
+SELECT current_setting('http_proxy'), current_setting('http_proxy_username'), current_setting('http_proxy_password')
 ----
-http://proxy.example.com:3128
-
-query I
-SELECT current_setting('http_proxy_username')
-----
-bob
-
-query I
-SELECT current_setting('http_proxy_password')
-----
-(empty)
+http://proxy.example.com:3128	bob	(empty)
 
 # An `@` that appears in the path component must not be treated as userinfo
 statement ok
@@ -69,15 +39,10 @@ SET http_proxy_username = ''
 statement ok
 SET http_proxy = 'http://proxy.example.com/path@with-at'
 
-query I
-SELECT current_setting('http_proxy')
+query III
+SELECT current_setting('http_proxy'), current_setting('http_proxy_username'), current_setting('http_proxy_password')
 ----
-http://proxy.example.com/path@with-at
-
-query I
-SELECT current_setting('http_proxy_username')
-----
-(empty)
+http://proxy.example.com/path@with-at	(empty)	(empty)
 
 # --- Malformed URLs --------------------------------------------------------
 
@@ -91,34 +56,19 @@ SET http_proxy_password = 'preexisting'
 statement ok
 SET http_proxy = 'http://proxy.example.com?token=a@b.com'
 
-query I
-SELECT current_setting('http_proxy')
+query III
+SELECT current_setting('http_proxy'), current_setting('http_proxy_username'), current_setting('http_proxy_password')
 ----
-http://proxy.example.com?token=a@b.com
-
-query I
-SELECT current_setting('http_proxy_username')
-----
-preexisting
-
-query I
-SELECT current_setting('http_proxy_password')
-----
-preexisting
+http://proxy.example.com?token=a@b.com	preexisting	preexisting
 
 # An `@` inside the fragment is not userinfo
 statement ok
 SET http_proxy = 'http://proxy.example.com#frag@ment'
 
-query I
-SELECT current_setting('http_proxy')
+query III
+SELECT current_setting('http_proxy'), current_setting('http_proxy_username'), current_setting('http_proxy_password')
 ----
-http://proxy.example.com#frag@ment
-
-query I
-SELECT current_setting('http_proxy_username')
-----
-preexisting
+http://proxy.example.com#frag@ment	preexisting	preexisting
 
 # Without an explicit scheme the URL is stored verbatim and no credential
 # parsing is attempted - `user:pass@host` is ambiguous (it could be userinfo
@@ -127,73 +77,38 @@ preexisting
 statement ok
 SET http_proxy = 'alice:s3cr3t@proxy.example.com:8080'
 
-query I
-SELECT current_setting('http_proxy')
+query III
+SELECT current_setting('http_proxy'), current_setting('http_proxy_username'), current_setting('http_proxy_password')
 ----
-alice:s3cr3t@proxy.example.com:8080
-
-query I
-SELECT current_setting('http_proxy_username')
-----
-preexisting
-
-query I
-SELECT current_setting('http_proxy_password')
-----
-preexisting
+alice:s3cr3t@proxy.example.com:8080	preexisting	preexisting
 
 # Same for a leading `@` with no scheme
 statement ok
 SET http_proxy = '@proxy.example.com:8080'
 
-query I
-SELECT current_setting('http_proxy')
+query III
+SELECT current_setting('http_proxy'), current_setting('http_proxy_username'), current_setting('http_proxy_password')
 ----
-@proxy.example.com:8080
-
-query I
-SELECT current_setting('http_proxy_username')
-----
-preexisting
-
-query I
-SELECT current_setting('http_proxy_password')
-----
-preexisting
+@proxy.example.com:8080	preexisting	preexisting
 
 # Empty userinfo (`http://@`) with a scheme strips the `@` and leaves
 # credentials untouched
 statement ok
 SET http_proxy = 'http://@'
 
-query I
-SELECT current_setting('http_proxy')
+query III
+SELECT current_setting('http_proxy'), current_setting('http_proxy_username'), current_setting('http_proxy_password')
 ----
-http://
-
-query I
-SELECT current_setting('http_proxy_username')
-----
-preexisting
+http://	preexisting	preexisting
 
 # Explicit empty password (`user:@host`) clears the password but keeps the user
 statement ok
 SET http_proxy = 'http://carol:@proxy.example.com:3128'
 
-query I
-SELECT current_setting('http_proxy')
+query III
+SELECT current_setting('http_proxy'), current_setting('http_proxy_username'), current_setting('http_proxy_password')
 ----
-http://proxy.example.com:3128
-
-query I
-SELECT current_setting('http_proxy_username')
-----
-carol
-
-query I
-SELECT current_setting('http_proxy_password')
-----
-(empty)
+http://proxy.example.com:3128	carol	(empty)
 
 # Multiple `@` in the userinfo: only the first separates userinfo from host.
 # The remainder is left in the URL (which downstream parsing will reject
@@ -207,63 +122,44 @@ SET http_proxy_password = ''
 statement ok
 SET http_proxy = 'http://dave:p@ss@proxy.example.com:8080'
 
-query I
-SELECT current_setting('http_proxy')
+query III
+SELECT current_setting('http_proxy'), current_setting('http_proxy_username'), current_setting('http_proxy_password')
 ----
-http://ss@proxy.example.com:8080
-
-query I
-SELECT current_setting('http_proxy_username')
-----
-dave
-
-query I
-SELECT current_setting('http_proxy_password')
-----
-p
+http://ss@proxy.example.com:8080	dave	p
 
 # A `:` colon inside the password is preserved (only the first `:` splits)
 statement ok
 SET http_proxy = 'http://eve:p:a:s:s@proxy.example.com:8080'
 
-query I
-SELECT current_setting('http_proxy_username')
+query III
+SELECT current_setting('http_proxy'), current_setting('http_proxy_username'), current_setting('http_proxy_password')
 ----
-eve
-
-query I
-SELECT current_setting('http_proxy_password')
-----
-p:a:s:s
+http://proxy.example.com:8080	eve	p:a:s:s
 
 # Leading `:` produces an empty username with the password set
 statement ok
 SET http_proxy = 'http://:onlypass@proxy.example.com:8080'
 
-query I
-SELECT current_setting('http_proxy_username')
+query III
+SELECT current_setting('http_proxy'), current_setting('http_proxy_username'), current_setting('http_proxy_password')
 ----
-(empty)
+http://proxy.example.com:8080	(empty)	onlypass
 
-query I
-SELECT current_setting('http_proxy_password')
-----
-onlypass
-
-# A bare `://` scheme separator with no authority is stored verbatim
+# A bare `://` scheme separator with no authority is stored verbatim, and
+# the previous block's credential state is preserved.
 statement ok
 SET http_proxy = '://'
 
-query I
-SELECT current_setting('http_proxy')
+query III
+SELECT current_setting('http_proxy'), current_setting('http_proxy_username'), current_setting('http_proxy_password')
 ----
-://
+://	(empty)	onlypass
 
-# Empty value is permitted (and clears the setting)
+# Empty value is permitted (clears http_proxy, leaves credentials alone)
 statement ok
 SET http_proxy = ''
 
-query I
-SELECT current_setting('http_proxy')
+query III
+SELECT current_setting('http_proxy'), current_setting('http_proxy_username'), current_setting('http_proxy_password')
 ----
-(empty)
+(empty)	(empty)	onlypass

--- a/test/sql/settings/http_proxy.test
+++ b/test/sql/settings/http_proxy.test
@@ -120,14 +120,17 @@ SELECT current_setting('http_proxy_username')
 ----
 preexisting
 
-# Empty userinfo (`@host`) strips the `@` and leaves credentials untouched
+# Without an explicit scheme the URL is stored verbatim and no credential
+# parsing is attempted - `user:pass@host` is ambiguous (it could be userinfo
+# or a literal hostname containing `@`), so we make no assumptions and leave
+# the existing credential settings alone.
 statement ok
-SET http_proxy = '@proxy.example.com:8080'
+SET http_proxy = 'alice:s3cr3t@proxy.example.com:8080'
 
 query I
 SELECT current_setting('http_proxy')
 ----
-proxy.example.com:8080
+alice:s3cr3t@proxy.example.com:8080
 
 query I
 SELECT current_setting('http_proxy_username')
@@ -139,7 +142,27 @@ SELECT current_setting('http_proxy_password')
 ----
 preexisting
 
-# A trailing `@` with no authority is similarly a no-op for credentials
+# Same for a leading `@` with no scheme
+statement ok
+SET http_proxy = '@proxy.example.com:8080'
+
+query I
+SELECT current_setting('http_proxy')
+----
+@proxy.example.com:8080
+
+query I
+SELECT current_setting('http_proxy_username')
+----
+preexisting
+
+query I
+SELECT current_setting('http_proxy_password')
+----
+preexisting
+
+# Empty userinfo (`http://@`) with a scheme strips the `@` and leaves
+# credentials untouched
 statement ok
 SET http_proxy = 'http://@'
 

--- a/test/sql/settings/http_proxy.test
+++ b/test/sql/settings/http_proxy.test
@@ -1,0 +1,80 @@
+# name: test/sql/settings/http_proxy.test
+# description: Test http_proxy setting parsing
+# group: [settings]
+
+# Plain host:port stays unchanged and does not touch credentials
+statement ok
+SET http_proxy = 'proxy.example.com:8080'
+
+query I
+SELECT current_setting('http_proxy')
+----
+proxy.example.com:8080
+
+query I
+SELECT current_setting('http_proxy_username')
+----
+(empty)
+
+query I
+SELECT current_setting('http_proxy_password')
+----
+(empty)
+
+# A scheme is preserved and `user:pass@` populates the credential settings
+statement ok
+SET http_proxy = 'https://alice:s3cr3t@proxy.example.com:8443'
+
+query I
+SELECT current_setting('http_proxy')
+----
+https://proxy.example.com:8443
+
+query I
+SELECT current_setting('http_proxy_username')
+----
+alice
+
+query I
+SELECT current_setting('http_proxy_password')
+----
+s3cr3t
+
+# Username only (no password) is supported
+statement ok
+SET http_proxy_password = ''
+
+statement ok
+SET http_proxy = 'http://bob@proxy.example.com:3128'
+
+query I
+SELECT current_setting('http_proxy')
+----
+http://proxy.example.com:3128
+
+query I
+SELECT current_setting('http_proxy_username')
+----
+bob
+
+query I
+SELECT current_setting('http_proxy_password')
+----
+(empty)
+
+# An `@` that appears in the path component must not be treated as userinfo
+statement ok
+SET http_proxy_username = ''
+
+statement ok
+SET http_proxy = 'http://proxy.example.com/path@with-at'
+
+query I
+SELECT current_setting('http_proxy')
+----
+http://proxy.example.com/path@with-at
+
+query I
+SELECT current_setting('http_proxy_username')
+----
+(empty)

--- a/test/sql/settings/http_proxy.test
+++ b/test/sql/settings/http_proxy.test
@@ -78,3 +78,169 @@ query I
 SELECT current_setting('http_proxy_username')
 ----
 (empty)
+
+# --- Malformed URLs --------------------------------------------------------
+
+# An `@` inside the query string is not userinfo
+statement ok
+SET http_proxy_username = 'preexisting'
+
+statement ok
+SET http_proxy_password = 'preexisting'
+
+statement ok
+SET http_proxy = 'http://proxy.example.com?token=a@b.com'
+
+query I
+SELECT current_setting('http_proxy')
+----
+http://proxy.example.com?token=a@b.com
+
+query I
+SELECT current_setting('http_proxy_username')
+----
+preexisting
+
+query I
+SELECT current_setting('http_proxy_password')
+----
+preexisting
+
+# An `@` inside the fragment is not userinfo
+statement ok
+SET http_proxy = 'http://proxy.example.com#frag@ment'
+
+query I
+SELECT current_setting('http_proxy')
+----
+http://proxy.example.com#frag@ment
+
+query I
+SELECT current_setting('http_proxy_username')
+----
+preexisting
+
+# Empty userinfo (`@host`) strips the `@` and leaves credentials untouched
+statement ok
+SET http_proxy = '@proxy.example.com:8080'
+
+query I
+SELECT current_setting('http_proxy')
+----
+proxy.example.com:8080
+
+query I
+SELECT current_setting('http_proxy_username')
+----
+preexisting
+
+query I
+SELECT current_setting('http_proxy_password')
+----
+preexisting
+
+# A trailing `@` with no authority is similarly a no-op for credentials
+statement ok
+SET http_proxy = 'http://@'
+
+query I
+SELECT current_setting('http_proxy')
+----
+http://
+
+query I
+SELECT current_setting('http_proxy_username')
+----
+preexisting
+
+# Explicit empty password (`user:@host`) clears the password but keeps the user
+statement ok
+SET http_proxy = 'http://carol:@proxy.example.com:3128'
+
+query I
+SELECT current_setting('http_proxy')
+----
+http://proxy.example.com:3128
+
+query I
+SELECT current_setting('http_proxy_username')
+----
+carol
+
+query I
+SELECT current_setting('http_proxy_password')
+----
+(empty)
+
+# Multiple `@` in the userinfo: only the first separates userinfo from host.
+# The remainder is left in the URL (which downstream parsing will reject
+# during the actual request) - we are robust, not strict.
+statement ok
+SET http_proxy_username = ''
+
+statement ok
+SET http_proxy_password = ''
+
+statement ok
+SET http_proxy = 'http://dave:p@ss@proxy.example.com:8080'
+
+query I
+SELECT current_setting('http_proxy')
+----
+http://ss@proxy.example.com:8080
+
+query I
+SELECT current_setting('http_proxy_username')
+----
+dave
+
+query I
+SELECT current_setting('http_proxy_password')
+----
+p
+
+# A `:` colon inside the password is preserved (only the first `:` splits)
+statement ok
+SET http_proxy = 'http://eve:p:a:s:s@proxy.example.com:8080'
+
+query I
+SELECT current_setting('http_proxy_username')
+----
+eve
+
+query I
+SELECT current_setting('http_proxy_password')
+----
+p:a:s:s
+
+# Leading `:` produces an empty username with the password set
+statement ok
+SET http_proxy = 'http://:onlypass@proxy.example.com:8080'
+
+query I
+SELECT current_setting('http_proxy_username')
+----
+(empty)
+
+query I
+SELECT current_setting('http_proxy_password')
+----
+onlypass
+
+# A bare `://` scheme separator with no authority is stored verbatim
+statement ok
+SET http_proxy = '://'
+
+query I
+SELECT current_setting('http_proxy')
+----
+://
+
+# Empty value is permitted (and clears the setting)
+statement ok
+SET http_proxy = ''
+
+query I
+SELECT current_setting('http_proxy')
+----
+(empty)


### PR DESCRIPTION
## Summary
Enhanced HTTP proxy configuration to automatically extract embedded credentials from proxy URLs and populate the corresponding username/password settings. This allows users to specify proxy credentials in a single URL string rather than managing separate settings.

## Key Changes
- **Credential extraction**: Added `ApplyHTTPProxyURL()` function that parses proxy URLs and extracts `user[:password]@` userinfo components, storing them in `http_proxy_username` and `http_proxy_password` settings
- **RFC 3986 compliance**: Correctly handles userinfo parsing by only treating `@` characters in the authority component as credential separators, ignoring `@` in path/query/fragment components
- **Environment variable precedence**: Updated `HTTPProxySetting::ResetGlobal()` to check environment variables in order: `https_proxy`, `HTTPS_PROXY`, `http_proxy`, `HTTP_PROXY` (preferring lowercase to avoid CGI httpoxy ambiguity)
- **URL normalization**: Removes extracted credentials from the stored proxy URL, leaving only the scheme and authority
- **Comprehensive test coverage**: Added 246-line test file covering valid URLs, edge cases (empty userinfo, multiple `@` characters, colons in passwords), and malformed URLs

## Implementation Details
- Credential settings are only modified when non-empty userinfo is found in the URL
- Empty userinfo (`@host`) or userinfo in query/fragment components are handled gracefully without affecting existing credentials
- Explicit empty password (`user:@host`) clears the password while preserving the username
- The implementation is robust to malformed URLs, leaving them unchanged rather than failing
- Updated setting descriptions to document the new credential extraction behavior

https://claude.ai/code/session_01GC39M53ozHzknQwf3M68BJ